### PR TITLE
Responsiveness for navbar controls and sidebar

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -141,6 +141,9 @@ html.dark {
 
 .editor-sidebar {
   @apply h-screen sticky top-0 border-l w-80 bg-gray-50 dark:bg-gray-900 dark:border-gray-700 overflow-y-auto flex-shrink-0;
+  @media (max-width: 1024px) {
+    @apply w-60;
+  }
 }
 .toasted.toasted-primary {
   @apply rounded-lg font-medium text-slate-800 dark:text-slate-100 bg-slate-100 dark:bg-slate-800 !important;
@@ -151,8 +154,32 @@ html.dark {
 .sponsor-btn {
   @apply border dark:border-gray-700 rounded-lg px-6 py-3 hover:bg-gray-100 dark:hover:bg-gray-700 text-sm focus:outline-none;
 }
+
+.navbar-container {
+  @apply border-t border-b sticky top-0 z-50 py-2.5 dark:border-gray-700 flex items-center px-8 navbar-frosted;
+}
+
+.navbar-heading {
+  position: absolute;
+  left: 2rem;
+  top: 1.4rem;
+  z-index: 0;
+}
+
+.nav-heading-spacer {
+  @apply w-48 h-10;
+}
+
+.navbar-controls {
+  @apply flex w-full justify-end z-10 flex-wrap;
+}
+
+.navbar-search-input {
+  @apply relative flex my-1.5 items-center overflow-hidden rounded-full bg-gray-50 dark:bg-gray-700 focus-within:bg-gray-100 dark:focus-within:bg-gray-800;
+}
+
 .navbar-btn {
-  @apply h-10 px-4 rounded-full flex items-center justify-center space-x-3 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 focus:outline-none focus:bg-gray-200;
+  @apply h-10 px-4 ml-4 my-1.5 rounded-full flex items-center justify-center space-x-3 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 focus:outline-none focus:bg-gray-200 whitespace-nowrap;
 }
 
 .expand-enter-active,

--- a/components/Base/Navbar.vue
+++ b/components/Base/Navbar.vue
@@ -1,56 +1,48 @@
 <template>
-  <div
-    class="h-[75px] border-t border-b sticky top-0 z-50 dark:border-gray-700 flex items-center justify-between px-8 flex-wrap navbar-frosted"
-  >
-    <p>
-      <span class="text-lg font-medium">{{ page.title }} Icons</span>
-      <span class="text-gray-600" v-if="page.subtitle"
-        >({{ page.subtitle }})</span
-      >
-    </p>
-    <div class="flex-space-x-4">
-      <div
-        class="relative flex items-center overflow-hidden rounded-full bg-gray-50 dark:bg-gray-700 focus-within:bg-gray-100 dark:focus-within:bg-gray-800"
-      >
-        <input
-          type="text"
-          class="focus:outline-none bg-transparent z-10 h-full rounded-l-full px-6 text-sm"
-          placeholder="Search (Press / to focus)"
-          ref="search"
-          @input="search"
-          autocomplete="new-password"
-        />
-        <button
-          class="h-10 w-10 flex-center bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 z-20 focus:outline-none focus:bg-gray-200"
-          @click="$refs.search.focus()"
-          aria-label="Search"
-        >
-          <FluentIconFilledSearch class="text-gray-500 h-5 w-5" />
+  <div class="navbar-container">
+      <p class="navbar-heading">
+        <span class="text-lg font-medium">{{ page.title }} Icons</span>
+        <span class="text-gray-600" v-if="page.subtitle">({{ page.subtitle }})</span>
+      </p>
+      <div class="navbar-controls">
+        <div class="nav-heading-spacer"></div>
+        <div class="navbar-search-input">
+          <input
+            type="text"
+            class="focus:outline-none bg-transparent z-10 h-full rounded-l-full px-6 text-sm"
+            placeholder="Search (Press / to focus)"
+            ref="search"
+            @input="search"
+            autocomplete="new-password"/>
+          <button
+            class="h-10 w-10 flex-center bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 z-20 focus:outline-none focus:bg-gray-200"
+            @click="$refs.search.focus()"
+            aria-label="Search">
+            <FluentIconFilledSearch class="text-gray-500 h-5 w-5" />
+          </button>
+        </div>
+        <nuxt-link
+          :to="altIcons.path"
+          class="navbar-btn"
+          :aria-label="`${altIcons.name} Icons`">
+          <FluentIconFilledPositionBackward class="h-5 w-5" />
+          <p class="text-sm">{{ altIcons.name }} Icons</p>
+        </nuxt-link>
+        <button @click="toggleDarkMode" class="navbar-btn" aria-label="Dark Mode">
+          <FluentIconOutlinedWeatherSunny
+            v-if="$colorMode.value === 'dark'"
+            class="h-5 w-5"
+          />
+          <FluentIconOutlinedWeatherMoon v-else class="h-5 w-5" />
+          <p class="text-sm">
+            {{ $colorMode.value === "dark" ? "Light" : "Dark" }} Mode
+          </p>
         </button>
+        <nuxt-link to="/favorites" class="navbar-btn" aria-label="Favorites">
+          <FluentIconOutlinedHeart class="h-5 w-5" />
+          <p class="text-sm">Favorites</p>
+        </nuxt-link>
       </div>
-      <nuxt-link
-        :to="altIcons.path"
-        class="navbar-btn"
-        :aria-label="`${altIcons.name} Icons`"
-      >
-        <FluentIconFilledPositionBackward class="h-5 w-5" />
-        <p class="text-sm">{{ altIcons.name }} Icons</p>
-      </nuxt-link>
-      <button @click="toggleDarkMode" class="navbar-btn" aria-label="Dark Mode">
-        <FluentIconOutlinedWeatherSunny
-          v-if="$colorMode.value === 'dark'"
-          class="h-5 w-5"
-        />
-        <FluentIconOutlinedWeatherMoon v-else class="h-5 w-5" />
-        <p class="text-sm">
-          {{ $colorMode.value === "dark" ? "Light" : "Dark" }} Mode
-        </p>
-      </button>
-      <nuxt-link to="/favorites" class="navbar-btn" aria-label="Favorites">
-        <FluentIconOutlinedHeart class="h-5 w-5" />
-        <p class="text-sm">Favorites</p>
-      </nuxt-link>
-    </div>
     <base-search-focus @keyup="focusSearch" />
   </div>
 </template>


### PR DESCRIPTION
Added responsiveness to the navbar controls and the sidebar. 

Solution isn't 100% ideal as I had to add a blank spacing div so that the 'Filled Icons' heading doesn't get overlapped by the controls when they wrap.

I personally would consider removing the 'Filled Icons' heading when the viewport no longer has enough space for both it and the controls.